### PR TITLE
Adding stopTimeout and ulimits

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,8 @@ locals {
     mountPoints  = [for val in var.mount_points : { containerPath = val.container_path, readOnly : val.read_only, sourceVolume : val.source_volume }]
     volumesFrom  = [for val in var.volumes_from : { sourceContainer = val.source_container, readOnly = val.read_only }]
     dependsOn    = [for val in var.dependencies : { containerName = val.container_name, condition = val.condition }]
+    stopTimeout  = var.stop_timeout
+
 
     logConfiguration = {
       logDriver     = var.log_driver

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ locals {
     } : null
 
     environment = var.environment_variables
+    ulimits.    = var.ulimits
     secrets     = [for s in var.secrets : { for key, val in s : key == "value_from" ? "valueFrom" : key => val }]
 
     portMappings = [for val in var.port_mappings : { protocol: val.protocol, containerPort = val.container_port, hostPort = val.host_port }]

--- a/main.tf
+++ b/main.tf
@@ -36,18 +36,18 @@ locals {
     memory = var.memory
 
     healthCheck = var.health_check != null ? {
-      command = var.health_check.command
-      interval = var.health_check.interval
-      timeout = var.health_check.timeout
-      retries = var.health_check.retries
+      command     = var.health_check.command
+      interval    = var.health_check.interval
+      timeout     = var.health_check.timeout
+      retries     = var.health_check.retries
       startPeriod = var.health_check.start_period
     } : null
 
     environment = var.environment_variables
-    ulimits.    = var.ulimits
+    ulimits     = var.ulimits
     secrets     = [for s in var.secrets : { for key, val in s : key == "value_from" ? "valueFrom" : key => val }]
 
-    portMappings = [for val in var.port_mappings : { protocol: val.protocol, containerPort = val.container_port, hostPort = val.host_port }]
+    portMappings = [for val in var.port_mappings : { protocol : val.protocol, containerPort = val.container_port, hostPort = val.host_port }]
     mountPoints  = [for val in var.mount_points : { containerPath = val.container_path, readOnly : val.read_only, sourceVolume : val.source_volume }]
     volumesFrom  = [for val in var.volumes_from : { sourceContainer = val.source_container, readOnly = val.read_only }]
     dependsOn    = [for val in var.dependencies : { containerName = val.container_name, condition = val.condition }]

--- a/variables.tf
+++ b/variables.tf
@@ -143,3 +143,9 @@ variable "ulimits" {
   description = "Container ulimit settings. This is a list of maps, where each map should contain \"name\", \"hardLimit\" and \"softLimit\""
   default     = null
 }
+
+variable "stop_timeout" {
+  type        = number
+  description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -133,3 +133,13 @@ variable log_driver_secrets {
   type        = set(object({ name = string, value_from = string }))
   default     = []
 }
+
+variable "ulimits" {
+  type = list(object({
+    name      = string
+    hardLimit = number
+    softLimit = number
+  }))
+  description = "Container ulimit settings. This is a list of maps, where each map should contain \"name\", \"hardLimit\" and \"softLimit\""
+  default     = null
+}


### PR DESCRIPTION
Currently, the module isn't able to leverage any ulimits of any sort on ECS containers. Nor is it possible to set a stopTimeout.
This PR resolves that, so these features are able to be used in the container definition as well. If there's no variable set, the value is ignored.