### PR TITLE
Add support for system controls

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,8 @@ locals {
     ulimits     = var.ulimits
     secrets     = [for s in var.secrets : { for key, val in s : key == "value_from" ? "valueFrom" : key => val }]
 
+    systemControls = var.system_controls
+
     portMappings = [for val in var.port_mappings : { protocol : val.protocol, containerPort = val.container_port, hostPort = val.host_port }]
     mountPoints  = [for val in var.mount_points : { containerPath = val.container_path, readOnly : val.read_only, sourceVolume : val.source_volume }]
     volumesFrom  = [for val in var.volumes_from : { sourceContainer = val.source_container, readOnly = val.read_only }]

--- a/variables.tf
+++ b/variables.tf
@@ -149,3 +149,12 @@ variable "stop_timeout" {
   description = "Time duration (in seconds) to wait before the container is forcefully killed if it doesn't exit normally on its own"
   default     = null
 }
+
+variable "system_controls" {
+  type = list(object({
+    namespace = string
+    value     = string
+  }))
+  description = "A list of namespaced kernel parameters to set in the container. This is a list of maps, where each map should contain \"namespace\" and \"value\""
+  default     = null
+}


### PR DESCRIPTION
This PR adds support for configuring system controls in ECS containers, as defined in https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_systemcontrols